### PR TITLE
Add missing attrs to tests package

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,11 @@
+import os
 import unittest
 import mock
+
+
+TESTS_PATH = os.path.abspath(os.path.dirname(__file__))
+ROOT_PATH = os.path.dirname(TESTS_PATH)
+FIXTURES_PATH = os.path.join(TESTS_PATH, 'fixtures')
 
 
 class BaseTestCase(unittest.TestCase):


### PR DESCRIPTION
* `test_tool` is using `ROOT_PATH` from `tests` package which was not committed as part of previous PR