### PR TITLE
Fix ElasticSearch collector readin API response on Python 3

### DIFF
--- a/elasticmetrics/http.py
+++ b/elasticmetrics/http.py
@@ -97,7 +97,7 @@ class HttpClient(object):
             logger.debug('requesting URL "{}"'.format(url))
             with closing(self._urlopen(request)) as response:
                 logger.debug('URL "{}" response code "{}". decoding JSON'.format(url, response.getcode()))
-                return json.load(response)
+                return json.loads(response.read().decode('utf-8'))
         except IOError as err:
             logger.error('failed to request URL "{}": {}'.format(url, err))
             raise ElasticMetricsRequestError('request error to URL "{}": {}'.format(url, err))

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -7,7 +7,7 @@ from . import BaseTestCase
 class TestElasticSearchCollector(BaseTestCase):
     def setUp(self):
         self.mock_urlopen = self.set_up_patch('elasticmetrics.http.urlopen')
-        self.mock_urlopen.return_value = self._mock_urlopen_response('{"_nodes": []}')
+        self.mock_urlopen.return_value = self._mock_urlopen_response(b'{"_nodes": []}')
 
     def test_elasitcsearch_collector_is_an_http_client_instance(self):
         es_collector = ElasticSearchCollector('localhost')


### PR DESCRIPTION
The response is `bytes` on Python3, but we didn't catch this because we're mocking responses in tests with string values.