### PR TITLE
Improved node metrics

### DIFF
--- a/elasticmetrics/metrics.py
+++ b/elasticmetrics/metrics.py
@@ -59,6 +59,10 @@ def node_performance_metrics(node_stats):
     if 'transport' in node_data:
         metrics['transport'] = node_data['transport']
 
+    # thread_pool metrics
+    if 'thread_pool' in node_data:
+        metrics['thread_pool'] = node_data['thread_pool']
+
     return metrics
 
 

--- a/elasticmetrics/metrics.py
+++ b/elasticmetrics/metrics.py
@@ -63,6 +63,11 @@ def node_performance_metrics(node_stats):
     if 'thread_pool' in node_data:
         metrics['thread_pool'] = node_data['thread_pool']
 
+    # indices metrics
+    indices_stats = node_data.get('indices')
+    if indices_stats:
+        metrics['indices'] = _get_node_indices_metrics(indices_stats)
+
     return metrics
 
 
@@ -144,6 +149,34 @@ def _get_node_jvm_metrics(jvm_stats):
         }
 
     return jvm_metrics
+
+
+def _get_node_indices_metrics(indices_stats):
+    """Return metrics from indices stats from the node, which is the "indices" key
+    in the response from the node stats API.
+
+    :param dict indics_stats: the "indices" key from node stats API response
+    :return: dict
+    """
+    indices_metrics = {}
+    metric_section_keys = {
+        'docs': ('count', 'deleted'),
+        'fielddata': ('evictions', 'memory_size_in_bytes'),
+        'query_cache': ('evictions', 'hit_count', 'miss_count', 'memory_size_in_bytes'),
+        'request_cache': ('evictions', 'hit_count', 'miss_count', 'memory_size_in_bytes'),
+        'search': ('fetch_current', 'query_current', 'scroll_current', 'suggest_current'),
+        'segments': ('count', 'memory_in_bytes', 'index_writer_memory_in_bytes',
+                     'fixed_bit_set_memory_in_bytes', 'doc_values_memory_in_bytes', 'version_map_memory_in_bytes'),
+        'store': ('size_in_bytes',),
+        'translog': ('operations', 'size_in_bytes', 'uncommitted_operations', 'uncommitted_size_in_bytes'),
+        'warmer': ('current', 'total'),
+    }
+
+    for section, section_keys in metric_section_keys.items():
+        if section in indices_stats:
+            indices_metrics[section] = _available_keys(indices_stats[section], section_keys)
+
+    return indices_metrics
 
 
 def _available_keys(dict_, keys):

--- a/elasticmetrics/metrics.py
+++ b/elasticmetrics/metrics.py
@@ -55,6 +55,10 @@ def node_performance_metrics(node_stats):
     if jvm_stats:
         metrics['jvm'] = _get_node_jvm_metrics(jvm_stats)
 
+    # transport metrics: inter node send/reads
+    if 'transport' in node_data:
+        metrics['transport'] = node_data['transport']
+
     return metrics
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -139,3 +139,11 @@ class TestNodePerformanceMetrics(BaseTestCase):
         # aggregated metrics
         self.assertEqual(buf_metrics['total']['count'], 86 + 1)
         self.assertEqual(buf_metrics['total']['used_in_bytes'], 540041224 + 5403)
+
+    def test_node_performance_metrics_returns_transport_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['transport'], dict)
+        self.assertEqual(metrics['transport']['rx_count'], 3351172)
+        self.assertEqual(metrics['transport']['rx_size_in_bytes'], 76369739396)
+        self.assertEqual(metrics['transport']['tx_count'], 3351172)
+        self.assertEqual(metrics['transport']['tx_size_in_bytes'], 14846089376)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -151,3 +151,77 @@ class TestNodePerformanceMetrics(BaseTestCase):
     def test_node_performance_metrics_returns_thread_pool_metrics(self):
         metrics = node_performance_metrics(MOCK_NODE_STATS)
         self.assertEqual(metrics['thread_pool'], MOCK_NODE_STATS['nodes']['abcd12345node']['thread_pool'])
+
+    def test_node_performance_metrics_returns_indices_docs_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['docs'], dict)
+        sub_metrics = metrics['indices']['docs']
+        self.assertEqual(sub_metrics['count'], 0)
+        self.assertEqual(sub_metrics['deleted'], 0)
+
+    def test_node_performance_metrics_returns_indices_fielddata_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['fielddata'], dict)
+        sub_metrics = metrics['indices']['fielddata']
+        self.assertEqual(sub_metrics['evictions'], 0)
+        self.assertEqual(sub_metrics['memory_size_in_bytes'], 0)
+
+    def test_node_performance_metrics_returns_indices_query_cache_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['query_cache'], dict)
+        sub_metrics = metrics['indices']['query_cache']
+        self.assertEqual(sub_metrics['evictions'], 0)
+        self.assertEqual(sub_metrics['hit_count'], 0)
+        self.assertEqual(sub_metrics['miss_count'], 0)
+        self.assertEqual(sub_metrics['memory_size_in_bytes'], 0)
+
+    def test_node_performance_metrics_returns_indices_request_cache_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['request_cache'], dict)
+        sub_metrics = metrics['indices']['request_cache']
+        self.assertEqual(sub_metrics['evictions'], 0)
+        self.assertEqual(sub_metrics['hit_count'], 0)
+        self.assertEqual(sub_metrics['miss_count'], 0)
+        self.assertEqual(sub_metrics['memory_size_in_bytes'], 0)
+
+    def test_node_performance_metrics_returns_indices_search_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['search'], dict)
+        sub_metrics = metrics['indices']['search']
+        self.assertEqual(sub_metrics['fetch_current'], 0)
+        self.assertEqual(sub_metrics['query_current'], 0)
+        self.assertEqual(sub_metrics['scroll_current'], 0)
+        self.assertEqual(sub_metrics['suggest_current'], 0)
+
+    def test_node_performance_metrics_returns_indices_segments_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['segments'], dict)
+        sub_metrics = metrics['indices']['segments']
+        self.assertEqual(sub_metrics['count'], 0)
+        self.assertEqual(sub_metrics['doc_values_memory_in_bytes'], 0)
+        self.assertEqual(sub_metrics['fixed_bit_set_memory_in_bytes'], 0)
+        self.assertEqual(sub_metrics['index_writer_memory_in_bytes'], 0)
+        self.assertEqual(sub_metrics['memory_in_bytes'], 0)
+        self.assertEqual(sub_metrics['version_map_memory_in_bytes'], 0)
+
+    def test_node_performance_metrics_returns_indices_store_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['store'], dict)
+        sub_metrics = metrics['indices']['store']
+        self.assertEqual(sub_metrics['size_in_bytes'], 0)
+
+    def test_node_performance_metrics_returns_indices_translog_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['translog'], dict)
+        sub_metrics = metrics['indices']['translog']
+        self.assertEqual(sub_metrics['operations'], 0)
+        self.assertEqual(sub_metrics['size_in_bytes'], 0)
+        self.assertEqual(sub_metrics['uncommitted_operations'], 0)
+        self.assertEqual(sub_metrics['uncommitted_size_in_bytes'], 0)
+
+    def test_node_performance_metrics_returns_indices_warmer_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertIsInstance(metrics['indices']['warmer'], dict)
+        sub_metrics = metrics['indices']['warmer']
+        self.assertEqual(sub_metrics['current'], 0)
+        self.assertEqual(sub_metrics['total'], 0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -147,3 +147,7 @@ class TestNodePerformanceMetrics(BaseTestCase):
         self.assertEqual(metrics['transport']['rx_size_in_bytes'], 76369739396)
         self.assertEqual(metrics['transport']['tx_count'], 3351172)
         self.assertEqual(metrics['transport']['tx_size_in_bytes'], 14846089376)
+
+    def test_node_performance_metrics_returns_thread_pool_metrics(self):
+        metrics = node_performance_metrics(MOCK_NODE_STATS)
+        self.assertEqual(metrics['thread_pool'], MOCK_NODE_STATS['nodes']['abcd12345node']['thread_pool'])


### PR DESCRIPTION
Adds [transport](https://www.elastic.co/guide/en/elasticsearch/guide/current/_monitoring_individual_nodes.html#_fs_and_network_sections),  [thread_pool](https://www.elastic.co/guide/en/elasticsearch/guide/current/_monitoring_individual_nodes.html#_threadpool_section) and [indices](https://www.elastic.co/guide/en/elasticsearch/guide/current/_monitoring_individual_nodes.html#_indices_section) to node performance metrics.