### PR TITLE
Format dotted paths

### DIFF
--- a/elasticmetrics/formatters.py
+++ b/elasticmetrics/formatters.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+
+
 def flatten_metrics(metrics, path_separator='.', prefix=''):
     """Format the metrics into a dictionary that maps unique paths to
     metric values. paths are separated by the path_separator character, default
@@ -22,3 +25,29 @@ def flatten_metrics(metrics, path_separator='.', prefix=''):
             flattened[current_path] = value
 
     return flattened
+
+
+def sort_flatten_metrics_iter(metrics_iter, path_separator='.', prefix=''):
+    """Format the list of metrics into an ordered dictionary, mapping paths to
+    metric values. Paths are separated by the path_separator character, default
+    is ".". Each set of metrics are flattened by "flatten_metrics", the results
+    are aggregated to a final ordered dict and returned as one data structure.
+    Repeated metric paths will be overriden by the latest occurrences.
+
+    See: flatten_metrics
+
+    :param iterable metrics: iterable of dictionary of metrics.
+    :param str path_separator: separate paths in flattened path from the hierarchy
+    :param str prefix: prefix for the metrics paths
+    :return OrderedDict: sorted flattened unique paths mapped to metric values
+    """
+    flattened = {}
+    for metrics in metrics_iter:
+        flattened.update(**flatten_metrics(metrics, path_separator, prefix))
+
+    sorted_paths = sorted(flattened.keys())
+    result = OrderedDict()
+    for path in sorted_paths:
+        result[path] = flattened[path]
+
+    return result

--- a/elasticmetrics/formatters.py
+++ b/elasticmetrics/formatters.py
@@ -1,0 +1,24 @@
+def flatten_metrics(metrics, path_separator='.', prefix=''):
+    """Format the metrics into a dictionary that maps unique paths to
+    metric values. paths are separated by the path_separator character, default
+    is ".".
+    Only dictionary containers are supported, as metrics are a hierarchy of names mapped
+    to numeric values.
+
+    :param dict metrics: dictionary of metrics.
+    :param str path_separator: separate paths in flattened path from the hierarchy
+    :param str prefix: prefix for the metrics paths
+    :return dict: flattened unique paths mapped to metric values
+    """
+    flattened = {}
+    for name in metrics:
+        value = metrics[name]
+        current_path = prefix + path_separator + name if prefix else name
+        if isinstance(value, dict):
+            sub_paths = flatten_metrics(value, path_separator, prefix=current_path)
+            for (subpath, value) in sub_paths.items():
+                flattened[subpath] = value
+        else:
+            flattened[current_path] = value
+
+    return flattened

--- a/tests/fixtures/node_metrics.json
+++ b/tests/fixtures/node_metrics.json
@@ -1,0 +1,280 @@
+{
+    "http": {
+        "total_opened": 10,
+        "current_open": 1
+    },
+    "process": {
+        "cpu": {
+            "percent": 0,
+            "total_in_millis": 251710
+        },
+        "open_file_descriptors": 320,
+        "max_file_descriptors": 1048576,
+        "mem": {
+            "total_virtual_in_bytes": 7133585408
+        }
+    },
+    "indices": {
+        "request_cache": {
+            "hit_count": 0,
+            "evictions": 0,
+            "memory_size_in_bytes": 0,
+            "miss_count": 0
+        },
+        "docs": {
+            "deleted": 17,
+            "count": 23639
+        },
+        "fielddata": {
+            "evictions": 0,
+            "memory_size_in_bytes": 0
+        },
+        "translog": {
+            "uncommitted_size_in_bytes": 21645489,
+            "operations": 15388,
+            "uncommitted_operations": 15388,
+            "size_in_bytes": 21645575
+        },
+        "search": {
+            "scroll_current": 0,
+            "suggest_current": 0,
+            "query_current": 0,
+            "fetch_current": 0
+        },
+        "query_cache": {
+            "hit_count": 0,
+            "evictions": 0,
+            "memory_size_in_bytes": 0,
+            "miss_count": 0
+        },
+        "segments": {
+            "fixed_bit_set_memory_in_bytes": 0,
+            "count": 12,
+            "memory_in_bytes": 118017,
+            "version_map_memory_in_bytes": 0,
+            "index_writer_memory_in_bytes": 0,
+            "doc_values_memory_in_bytes": 30176
+        },
+        "warmer": {
+            "total": 1727,
+            "current": 0
+        },
+        "store": {
+            "size_in_bytes": 9601277
+        }
+    },
+    "thread_pool": {
+        "security-token-key": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "ml_datafeed": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "fetch_shard_store": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "flush": {
+            "largest": 3,
+            "threads": 1,
+            "completed": 4,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "force_merge": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "bulk": {
+            "largest": 8,
+            "threads": 8,
+            "completed": 3078,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "fetch_shard_started": {
+            "largest": 2,
+            "threads": 1,
+            "completed": 2,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "management": {
+            "largest": 3,
+            "threads": 3,
+            "completed": 11292,
+            "rejected": 0,
+            "active": 1,
+            "queue": 0
+        },
+        "listener": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "search": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "refresh": {
+            "largest": 3,
+            "threads": 3,
+            "completed": 46128,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "ml_autodetect": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "watcher": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "snapshot": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "warmer": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "get": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "ml_utility": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "index": {
+            "largest": 0,
+            "threads": 0,
+            "completed": 0,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        },
+        "generic": {
+            "largest": 4,
+            "threads": 4,
+            "completed": 21628,
+            "rejected": 0,
+            "active": 0,
+            "queue": 0
+        }
+    },
+    "jvm": {
+        "gc": {
+            "collection_count": 337,
+            "collectors": {
+                "young": {
+                    "collection_count": 335,
+                    "collection_time_in_millis": 2189
+                },
+                "old": {
+                    "collection_count": 2,
+                    "collection_time_in_millis": 143
+                }
+            },
+            "collection_time_in_millis": 2332
+        },
+        "threads": {
+            "count": 46,
+            "peak_count": 46
+        },
+        "buffer_pools": {
+            "direct": {
+                "used_in_bytes": 151760847,
+                "total_capacity_in_bytes": 151760846,
+                "count": 41
+            },
+            "mapped": {
+                "used_in_bytes": 9437571,
+                "total_capacity_in_bytes": 9437571,
+                "count": 24
+            },
+            "total": {
+                "used_in_bytes": 161198418,
+                "total_capacity_in_bytes": 161198417,
+                "count": 65
+            }
+        },
+        "mem": {
+            "heap_committed_in_bytes": 1037959168,
+            "heap_used_percent": 27,
+            "non_heap_committed_in_bytes": 132747264,
+            "non_heap_used_in_bytes": 124176936,
+            "heap_max_in_bytes": 1037959168,
+            "heap_used_in_bytes": 287736072
+        }
+    },
+    "fs": {
+        "total": {
+            "total_in_bytes": 57866743808,
+            "free_in_bytes": 15557791744,
+            "available_in_bytes": 12594728960
+        }
+    },
+    "transport": {
+        "tx_size_in_bytes": 0,
+        "server_open": 0,
+        "rx_count": 0,
+        "tx_count": 0,
+        "rx_size_in_bytes": 0
+    }
+}
+

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,61 @@
+import os
+import json
+from elasticmetrics.formatters import flatten_metrics
+from . import BaseTestCase, FIXTURES_PATH
+
+
+FIXTURE_NODEMETRICS = os.path.join(FIXTURES_PATH, 'node_metrics.json')
+
+with open(FIXTURE_NODEMETRICS, 'rt') as fh:
+    MOCK_NODE_METRICS = json.load(fh)
+
+
+class TestFlattenMetrics(BaseTestCase):
+    def test_flatten_metrics_returns_a_dict_of_dot_separated_paths_from_metrics(self):
+        expected_metrics = {
+            'http.total_opened': 10,
+            'http.current_open': 1,
+            'process.cpu.percent': 0,
+            'process.cpu.total_in_millis': 251710,
+            'process.mem.total_virtual_in_bytes': 7133585408,
+            'jvm.gc.collectors.young.collection_count': 335,
+            'jvm.threads.count': 46,
+            'jvm.threads.peak_count': 46,
+            'fs.total.total_in_bytes': 57866743808,
+            'fs.total.free_in_bytes': 15557791744,
+            'fs.total.available_in_bytes': 12594728960,
+            'transport.server_open': 0,
+        }
+        flattened = flatten_metrics(MOCK_NODE_METRICS)
+
+        for key, value in expected_metrics.items():
+            self.assertIn(key, flattened)
+            self.assertEqual(flattened[key], value)
+
+    def test_flatten_metrics_applies_path_separator_if_specified(self):
+        expected_metrics = {
+            'http->current_open': 1,
+            'process->cpu->percent': 0,
+            'process->cpu->total_in_millis': 251710,
+            'jvm->gc->collectors->young->collection_count': 335,
+            'jvm->threads->count': 46,
+            'fs->total->total_in_bytes': 57866743808,
+            'fs->total->available_in_bytes': 12594728960,
+        }
+        flattened = flatten_metrics(MOCK_NODE_METRICS, path_separator='->')
+
+        for key, value in expected_metrics.items():
+            self.assertIn(key, flattened)
+            self.assertEqual(flattened[key], value)
+
+    def test_flatten_metrics_prefixes_the_paths_with_the_specified_prefix(self):
+        expected_metrics = {
+            'mynode.http.total_opened': 10,
+            'mynode.http.current_open': 1,
+            'mynode.process.cpu.percent': 0,
+        }
+        flattened = flatten_metrics(MOCK_NODE_METRICS, prefix='mynode')
+
+        for key, value in expected_metrics.items():
+            self.assertIn(key, flattened)
+            self.assertEqual(flattened[key], value)


### PR DESCRIPTION
* add formatting metrics as flattened dict of `dot.separated.paths` mapped to values. This is a common format for time series backends (for example Graphite)
* CLI tool supports `--dotted-paths` option (mutually exclusive with `--raw-stats`) to printout the metrics in dotted paths instead of JSON. `--node-alias` option can be used to prefix metrics

```
(elasticmetrics) farzad@farzad-pc ~/w/elasticmetrics (format-dotted-path)> python -m elasticmetrics.tool --help
usage: elasticmetrics.tool [-h] [--host HOST] [--port PORT] [--user USER]
                           [--password PASSWORD] [--ssl] [--insecure]
                           [--verbose] [--quiet] [--collect COLLECT]
                           [--version] [--raw-stats | --dotted-paths]
                           [--node-alias NODE_ALIAS]
...
  --dotted-paths        output metrics named as dotted paths mapped to values
  --node-alias NODE_ALIAS
                        alias for the node. Used as prefix for metrics paths
```

Using `--dotted-paths` option:
```
(elasticmetrics) farzad@farzad-pc ~/w/elasticmetrics (format-dotted-path)> python -m elasticmetrics.tool --dotted-paths 
cluster.active_primary_shards 1
...
cluster.task_max_waiting_in_queue_millis 0
fs.total.available_in_bytes 10359042048
...
```

and adding `--node-alias`:
```
(elasticmetrics) farzad@farzad-pc ~/w/elasticmetrics (format-dotted-path)> python -m elasticmetrics.tool --dotted-paths --node-alias myes
cluster.active_primary_shards 1
...
cluster.task_max_waiting_in_queue_millis 0
myes.fs.total.available_in_bytes 10358661120
...
```